### PR TITLE
Updated topic content to enhance clarity (Fixes Issue #20)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ Summary of responsibilities of Central EGA nodes (EMBL-EBI & CRG) and Federated 
 | Central EGA Node | Federated EGA Node |
 | ---------------- | ------------------ |
 | Hosts data | Hosts and/or owns data |
-| Shares metadata & allows global discovery | Shares metadata to allow global discovery |
+| Shares metadata and provides global discovery | Shares metadata to enable global discovery |
 | Accepts data from all around the world | Accepts 3rd party data from jurisdiction |
 | Has Helpdesk for Central EGA data | Has Helpdesk responsible for own data/jurisdiction |
 | Chairs the Federated EGA Committees | Participates actively in the Federated EGA Committees |

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,7 +64,9 @@ One typical path for becoming a full Federated EGA member:
 
 <img src="./assets/img/Path-to-becoming-FEGA-member-v1.0.svg" alt="Colored diagram with icons and descriptions of technical and governance steps an interested Federated EGA node needs to complete to join the Network." width="1200"  align="right" />
 
-These materials guide you through onboarding information from the experiences of other nodes. Take what you find useful to apply to your own node development.
+These materials guide you through onboarding information from the experiences of other nodes. Take what you find useful to apply to your own node development. 
+
+You can also use the [Federated EGA Maturity Model](https://inab.github.io/fega-mm/) to plan and drive your own node's development. The Maturity Model is divided into different domains, sub-domains, and maturity indicators which closely align with the topics outlined in these materials. Here you can [read more about the FEGA Maturity Model](https://ega-archive.github.io/FEGA-onboarding/topics/maturity-model/).
 
 There is no time limit on establishing a Federated EGA Node. Onboarding will take more or less time depending on existing infrastructure and governance models, availability of funding and resources, user needs, and other factors.
 

--- a/docs/topics/governance-legal/index.md
+++ b/docs/topics/governance-legal/index.md
@@ -39,10 +39,10 @@ Understand more about the current [use cases and architecture for the Federated 
 
 ### Organisation
 
-Here is described the [Federated EGA Structure and Organization](https://ega-archive.org/files/EGA-Federation-Structure-v1.1.pdf). Federated EGA is broadly organised into two main types of nodes: Central EGA nodes (maintained by EMBL-EBI and CRG) and Federated EGA nodes (maintained at national or regional levels). Read the document linked above to learn more about the roles and responsiblities of each type of node.
+Here is described the [Federated EGA Structure and Organization](https://ega-archive.org/files/EGA-Federation-Structure-v1.1.pdf). Federated EGA is broadly organised into two main types of nodes: Central EGA nodes (maintained by EMBL-EBI and CRG) and Federated EGA nodes (maintained at national or regional levels). Read the document linked above to learn more about the roles and responsibilities of each type of node.
 
 Federated EGA is governed by two permanent committees:
-- The **Federated EGA Strategic Committee** [(Terms of Reference)](https://ega-archive.org/files/ToR-Federated-EGA-Strategic-Committee-v1.1.pdf) provides direction and strategic planning for the Federated EGA. The Committee receives input from the EGA Strategic Committee and provides feedback for the EGA strategic roadmap.
+- The **Federated EGA Strategic Committee** [(Terms of Reference)](https://ega-archive.org/files/ToR-Federated-EGA-Strategic-Committee-v1.1.pdf) provides direction and strategic planning for the Federated EGA. The Committee receives input from the Central EGA Strategic Committee and provides feedback for the EGA strategic roadmap.
 - The **Federated EGA Operations Committee** [(Terms of Reference)](https://ega-archive.org/files/ToR-Federated-EGA-Operations-Committee-v1.1.pdf) reviews operational performance and coordinates technical implementation roadmaps of the Federated EGA. The Committee receives advice from and provides operational reporting to the Federated EGA Strategic Committee.
 
 Additional **Federated EGA Working Groups** are established, as needed. Working groups can be initiated from either of the Committee.

--- a/docs/topics/governance-legal/index.md
+++ b/docs/topics/governance-legal/index.md
@@ -35,7 +35,7 @@ Genetic data generated in a healthcare context is subject to more stringent info
 
 ### Use cases
 
-Understand more about the current [use cases and architecture for the Federated EGA](https://zenodo.org/record/4893063) as reported by the inaugural Federated EGA nodes.
+Understand more about the current [use cases and architecture for the Federated EGA](https://zenodo.org/record/4893063). Here you can read about the requirements and national use cases of early engaged Federated EGA Nodes which aim to be addressed by joining the Federated EGA. The report also describes how specific use cases can be supported by Federated EGA, for example by a governance structure made up of permanent committees and ad hoc working groups, the use of global and community standards, and guidelines for how data/metadata can be shared within the network. 
 
 ### Organisation
 

--- a/docs/topics/technical-operational/index.md
+++ b/docs/topics/technical-operational/index.md
@@ -44,9 +44,14 @@ It is useful to establish SOPs for common node operational tasks to enable consi
 
 Standard interactions between Central EGA and Federated EGA node Helpdesk staff have been developed into a set of SOPs. Follow these SOPs below.
 
-#### Shared FEGA<->CEGA SOPs
+#### Shared FEGA &harr; CEGA SOPs
+
+The following SOPs must be followed as part of current FEGA &harr; CEGA node interactions during the submission process:
+
 - [Federated EGA Request from submitter to submit to FEGA node](https://docs.google.com/document/d/1c5YfLqGjCmRlG0NF9lsuU6IWUrCq4u8Ug3Ye5xMrxtI/edit?usp=sharing)
 - [Federated EGA Metadata Check and Release Protocol](https://docs.google.com/document/d/1v7l_ODdh-yxyhWl8Y8R3IZC2hEy5x8KgjBQmFyEyGgw/edit?usp=sharing)
+
+Here you can find more information about [data/metadata flow within the Federated EGA network](topics/data-metadata-management/#3-understand-data-definitions-and-flow).
 
 Central EGA Helpdesk have developed a set of SOPs to harmonise both user-facing processes and internal processes. Explore some examples of these SOPs below (and organised **[here](https://drive.google.com/drive/folders/14yFvXOxRyGl-ENogIB5TdogIUdL-gmfk?usp=sharing)**). Please note these are example SOPs and will need to be adapted to how your node operates!
 

--- a/docs/topics/technical-operational/index.md
+++ b/docs/topics/technical-operational/index.md
@@ -83,10 +83,11 @@ Engage in FEGA discussions happening with existing and interested FEGA nodes wit
 
 ## 3. Evaluate your implementation
 
-- Assess the technical and operational maturation of your node by doing a self-assessment against the [Federated EGA Maturity Model](https://inab.github.io/fega-mm/)
-- Determine compliance of services with FEGA specifications by performing [compliance tests](TBD)
-- Evaluate ability to scale services by performing [stress tests](TBD)
-- Demonstrate the full set of FEGA node services for users by planning your [FEGA end-to-end demonstrator](https://docs.google.com/document/d/1m7WDC112e73Kw79baZcsRsQOkAAGKtp_AiqJRhrgtUk/edit?usp=sharing)
+- Understand the domains in which a node matures using the [Federated EGA Maturity Model](https://ega-archive.github.io/FEGA-onboarding/topics/maturity-model/)
+- Assess the technical and operational maturation of your node by doing a **self-assessment against the Federated EGA Maturity Model** (Coming soon!)
+- Demonstrate the full set of node services for users by planning your [Federated EGA end-to-end demonstrator](https://docs.google.com/document/d/1m7WDC112e73Kw79baZcsRsQOkAAGKtp_AiqJRhrgtUk/edit?usp=sharing)
+- Determine compliance of services with FEGA specifications by performing **compliance tests** (Coming soon!)
+- Evaluate ability to scale services by performing **stress tests** (Coming soon!)
 
 ## 4. What's next?
 

--- a/docs/topics/technical-operational/index.md
+++ b/docs/topics/technical-operational/index.md
@@ -34,7 +34,7 @@ Welcome! If you are involved in technical or operational aspects of establishing
 
 ### Software
 
-A minimal Federated EGA node can be set up on your local infrastructure using the [localEGA software (GitHub repository)](https://github.com/EGA-archive/LocalEGA) and the associated [Readthedocs](https://localega.readthedocs.io/) webpages.
+A minimal Federated EGA node can be set up on your local infrastructure using the [localEGA software (GitHub repository)](https://github.com/EGA-archive/LocalEGA) and the associated [Readthedocs](https://localega.readthedocs.io/) webpages. It is not required to use the localEGA software suite, but it is a great option instead of developing your Federated EGA node software from scratch.
 
 More information about the local EGA software and its implementation can be found in this report for [ELIXIR-CONVERGE: Implementation and documentation to create an operational EGA node (D7.2)](https://zenodo.org/record/4893191) (report, 2 June 2021).
 


### PR DESCRIPTION
Changes made:

1. Gov & Legal page
    - Use Cases: Added sentence explaining the Use Cases are other resources joining FEGA.
    - Organisation: Added missing "Central" to "EGA Strategic Committee”
1. Tech & Ops page
    - Software: Clarified that installing localEGA software is optional
    - Shared FEGA - CEGA SOPs: Clarified communication between CEGA and FEGA
    - Evaluate implementation: Added link to the "Maturity Model" page
1. Establishing a FEGA Node (main) page
    - Added sentence to clarify use of Maturity Model and linking to the page.
    - In the table: Clarified discovery responsibility of CEGA and FEGA nodes
    - How do I start: Skipped these changes in this PR; already addressed in PR #19