### PR TITLE
Issue-31 - Added link to CA

### DIFF
--- a/docs/topics/governance-legal/index.md
+++ b/docs/topics/governance-legal/index.md
@@ -53,7 +53,7 @@ Additional **Federated EGA Working Groups** are established, as needed. Working 
 
 ### FEGA Collaboration Agreement
 
-Inclusion in the Federated EGA is codified by signing of the **Federated EGA Collaboration Agreement** (link coming soon!) between Central EGA (represented by the European Molecular Biology Laboratory and Fundació Centre De Regulació Genòmica) and the Federated EGA node.
+Inclusion in the Federated EGA is codified by signing of the <a href="https://drive.google.com/file/d/1QAKABRB5ZxAJlQSwFHaJ3e6TdtwZaCYs/view" target="_blank">**Federated EGA Collaboration Agreement**</a> (CA) between Central EGA (represented by the European Molecular Biology Laboratory and Fundació Centre De Regulació Genòmica) and the Federated EGA node. Nodes are welcome to make a copy of this current version of the CA to start its review with their legal teams and understand the responsibilities of joining FEGA. Nevertheless, this version (the one with a watermark) shall not be signed: the official version needs to be obtained from FEGA prior signing through its official channels. 
 
 ### Data Processing Agreement (DPA)
 


### PR DESCRIPTION
Both Silvia and I added some context to the Collaboration Agreement (CA) to the legal-governance section of the ReadTheDocs.

## Description
* Added link of the Collaboration Agreement to https://ega-archive.github.io/FEGA-onboarding/topics/governance-legal/#fega-collaboration-agreement
* Added context of the current version of the CA to https://ega-archive.github.io/FEGA-onboarding/topics/governance-legal/#fega-collaboration-agreement

## Motivation and Context
* New link of the CA was available.

## How has this been tested?
* Have not tested the documentation changed, but used same format of text from the same document. 

## What should reviewers focus on?
* The Link works and redirects to the current CA version
* Context of the version is self explanatory and easy to understand.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change which adds new content)
- [x] Modified content (non-breaking change which modifies existing content)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] I have read the CONTRIBUTING.md guide.
- [x] My changes follow the code style of this project.
- [x] I have updated supporting documentation, if required.
- [x] I have added my details to the CONTRIBUTORS.yaml file.
